### PR TITLE
Changes

### DIFF
--- a/sml1_imana.m~
+++ b/sml1_imana.m~
@@ -1,4 +1,4 @@
-function varargout=sml1_imana_temp2(what,varargin)
+function varargout=sml1_imana(what,varargin)
 
 % ------------------------- Directories -----------------------------------
 baseDir         ='/Users/eberlot/Documents/Data/SuperMotorLearning';
@@ -179,7 +179,7 @@ anatNum    = {[10:14],...
           
 loc_AC     = {[-112 -165 -176],...
               [-106 -173 -163],...
-              [-108 -172 -162],...
+              [-107 -178 -163],...
               [-103 -162 -167]};
 
 % Other random notes %
@@ -190,6 +190,7 @@ loc_AC     = {[-112 -165 -176],...
 %       dat files: 192,193,194,195,202(!!!),197,198,199,200,201
 % s04 - scan 2: two runs repeated / replaced
 %       dat files: - ADD!!!!
+
 
 % ------------------------------ Analysis Cases --------------------------------
 switch(what)
@@ -971,8 +972,13 @@ switch(what)
             J.timing.fmri_t0 = 1;
             
             L = getrow(D,D.ScanSess==sessN);    % only blocks of that scan session
-            uniqrun = unique(L.BN);
-            
+            if (sn==2 & sessN==3)
+                uniqrun = [181,182,191,184,185,186,187,188,189,190];
+            elseif (sn==2 & sessN==4)
+                uniqrun = [192,193,194,195,202,197,198,199,200,201];
+            else
+                uniqrun = unique(L.BN);
+            end
             % Loop through runs. 
             for r = 1:numruns_task_sess                                            
                 R = getrow(L,L.BN==uniqrun(run_task(1,r))); % 1-8 func runs of the session
@@ -1102,6 +1108,7 @@ switch(what)
                 end
         end;
         cd(cwd);
+        
     case '3c_GLM_FoSEx' % ------- GLM with separate regressors for first / second execution --
         % fits regressors separately for FoSEx
     case 'GLM_make_FoSEx'
@@ -2307,9 +2314,27 @@ switch(what)
         %
         % See blurbs in each SEARCH case to understand what they do.
         % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  
+    case 'MASK_combine'
+        % combine glm masks of all runs, create one mask overall
+        
+        vararginoptions(varargin,{'sn'});
+        for s = sn
+            for sess = 1:sess_sn(sn)
+                file = fullfile(glmSessDir{sess},subj_name{s},'mask.nii');
+                V = spm_vol(file);
+                mask(:,:,:,sess)=spm_read_vols(V);
+            end
+            maskNew=mask(:,:,:,1).*mask(:,:,:,2).*mask(:,:,:,3).*mask(:,:,:,4);
+            dest = fullfile(regDir, ['mask_' subj_name{sn} '.nii']);
+            V.fname=dest;
+            V.dim=size(maskNew);
+            V=rmfield(V,'descrip');
+            V.descrip = 'combined_mask';
+            spm_write_vol(V,maskNew);
+        end
     case 'ROI_define'                                                       % STEP 5.1   :  Define ROIs
 
-        vararginoptions(varargin,{'sn','sessN'});
+        vararginoptions(varargin,{'sn'});
         for s=sn
             R=[];
             for h=1:2
@@ -2317,7 +2342,8 @@ switch(what)
                 caretSubjDir = fullfile(caretDir,['x' subj_name{s}]);  
                % suitSubjDir = fullfile(suitDir,'anatomicals',subj_name{s});
 
-                file = fullfile(glmSessDir{sessN},subj_name{s},'mask.nii');
+               file = fullfile(regDir,['mask_' subj_name{s} '.nii']); % mask constructed in mask_combine
+                %file = fullfile(glmSessDir{sessN},subj_name{s},'mask.nii');
                 
                  for i=1:numregions_surf
                     R{i+(h-1)*numregions_surf}.type='surf_nodes';
@@ -2592,10 +2618,13 @@ switch(what)
                 So.RDM_nocv = distance_euclidean(betaW',D.seqNumb)';
                 So.RDM      = rsa.distanceLDC(betaW,D.run,D.seqNumb);
                 % trained seq
-                [G_train, Sig_train] = pcm_estGCrossval(betaW(D.seqType==1,:),D.run(D.seqType==1),D.seqNumb(D.seqType==1));
-                So.eigTrain = sort(eig(G_train)','descend');    % sorted eigenvalues
+                H=eye(6)-ones(6,6)./6;  % centering matrix!
+                [G_train, Sig_train] = pcm_estGCrossval(betaW(D.seqType==1,:),D.run(D.seqType==1),D.seqNumb(D.seqType==1));   
+                G_trainCent = H*G_train*H;  % double centered G matrix - rows and columns
+                So.eigTrain = sort(eig(G_trainCent)','descend');    % sorted eigenvalues
                 [G_untrain, Sig_untrain] = pcm_estGCrossval(betaW(D.seqType==2,:),D.run(D.seqType==2),D.seqNumb(D.seqType==2));
-                So.eigUntrain = sort(eig(G_untrain)','descend');
+                G_untrainCent = H*G_untrain*H;  % double centered G matrix - rows and columns
+                So.eigUntrain = sort(eig(G_untrainCent)','descend');
                 % untrained seq
                 % indexing fields
                 So.SN       = s;
@@ -2656,7 +2685,7 @@ switch(what)
         % % save
         save(fullfile(regDir,sprintf('sess%d_LOC_reg_statsAllSeq.mat',sessN)),'-struct','To');
         fprintf('\nDone.\n')  
-    case 'ROI_patternconsistency'                                           % OPTIONAL   :  Calculates pattern consistencies for each subject in roi across glms.
+    case 'ROI_beta_consist_witSess'                                           % OPTIONAL   :  Calculates pattern consistencies for each subject in roi across glms.
         % pattern consistency for specified roi
         % Pattern consistency is a measure of the proportion of explained
         % beta variance across runs within conditions. 
@@ -2667,64 +2696,186 @@ switch(what)
         %
         % enter sn, region, glm #, beta: 0=betaW, 1=betaUW, 2=raw betas
         % (1) Set parameters
-        glm = 2;
+        sessN = 1;
         sn  = 1;
         roi = 2; % default LH primary motor cortex
-        beta = 1;  % RAW or UW betas produce the best effect
+        betaChoice = 'uw';  % raw / uw / mw -> MW performs the best!
         removeMean = 'yes'; % are we removing pattern means for patternconsistency?
-        vararginoptions(varargin,{'sn','glm','roi','beta','removeMean'});
+        vararginoptions(varargin,{'sn','glm','roi','betaChoice','removeMean'});
         
         if strcmp(removeMean,'yes')
-             keepmean = 1; % we are removing the mean
-        else keepmean = 0; % we are keeping the mean (yeilds higher consistencies but these are biased)
+             rm = 1; % we are removing the mean
+        else rm = 0; % we are keeping the mean (yeilds higher consistencies but these are biased)
         end
   
         Rreturn=[];
         %========%
-        for g=glm
-            T = load(fullfile(regDir,sprintf('glm%d_reg_betas.mat',g))); % loads in struct 'T'
+        for s=sessN
+            T = load(fullfile(regDir,sprintf('reg_betas_sess%d.mat',s))); % loads in struct 'T'
             for r=roi
                 Rall=[]; %prep output variable
                 for s=sn
                     S = getrow(T,(T.SN==s & T.region==r));
-                    runs = 1:numruns(s);
-                    switch(beta)
-                        case 0
+                    runs = 1:numruns_task_sess; % 8 func runs
+                    switch(betaChoice)
+                        case 'raw'
                             betaW  = S.betaW{1}; 
-                        case 1
+                        case 'uw'
                             betaW  = S.betaUW{1}; 
-                        case 2
+                        case 'mw'
                             betaW  = S.betaRAW{1}; 
                     end
                     
                     % make vectors for pattern consistency func
-                    conditionVec = kron(ones(numel(runs),1),[1:19]');
-                    partition    = kron(runs',ones(19,1));
+                    conditionVec = kron(ones(numel(runs),1),[1:12]');
+                    partition    = kron(runs',ones(12,1));
                     % calculate the pattern consistency
-                    R2   = rsa_patternConsistency(betaW,partition,conditionVec,'removeMean',keepmean);
+                    R2   = rsa_patternConsistency(betaW,partition,conditionVec,'removeMean',rm);
                     Rall = [Rall,R2];
                 end
                 Rreturn = [Rreturn;Rall];
             end
         end
         varargout = {Rreturn};
+        fprintf('The consistency for %s betas in region %s is',betaChoice,regname{roi});
         % output arranged such that each row is an roi, each col is subj
         
         %_______________    
-    case 'ROI_betwSess_consist'
+    case 'ROI_beta_consist_betwSess'
         % evaluate consistency of measures (psc, beta, z-scores) across
         % sessions for finger mapping
         
         sn  = 1;
-        roi = 2;
-        betaChoice = 'uni'; % options: uni / multi / raw
-        vararginoptions(varargin,{'sn','roi','betaChoice'});
-
+        reg = 1:7;
+        removeMean = 'yes'; % are we removing pattern means for patternconsistency?
+        betaChoice = 'multi'; % options: uni / multi / raw
+        seq = 'untrained';
+        vararginoptions(varargin,{'sn','reg','betaChoice','removeMean','seq'});
+        
+        if strcmp(removeMean,'yes')
+             rm = 1; % we are removing the mean
+        else rm = 0; % we are keeping the mean (yeilds higher consistencies but these are biased)
+        end
+        
+       for  roi = reg;
         CS=[];  % separate per digit
         PS=[];  % across all digits
+        for sessN = 1:4; % per session
+            C=[];P=[];
+            T = load(fullfile(regDir,sprintf('reg_betas_sess%d.mat',sessN))); % loads region data (T)
         
-        for sessN = 1:4 % per session
-            C=[];
+            switch (betaChoice)
+            case 'uni'
+                beta = T.betaUW;
+            case 'multi'
+                beta = T.betaW;
+            case 'raw'
+                beta = T.betaRAW;
+            end
+        
+            runs=1:numruns_task_sess;
+            conditionVec = kron(ones(numel(runs),1),[1:12]');
+            
+            switch(seq)
+                case 'trained'
+                    idx=1:6;
+                case 'untrained'
+                    idx=7:12;
+            end
+
+            %C.beta=beta{roi};   
+            for d = 1:6 %sequences
+                C.beta_seq(d,:)=mean(beta{roi}(conditionVec==idx(d),:),1);  % beta values for each digit (avrg across two blocks)
+                C.psc_seq(d,:)=mean(beta{roi}(conditionVec==idx(d),:),1)./mean(beta{roi}(end-7:end,:),1).*100;
+                C.zscore_seq(d,:) = (C.beta_seq(d,:)-mean(C.beta_seq(d,:)))./std(C.beta_seq(d,:));
+            end
+            
+            %C.zscore_seq = bsxfun(@rdivide,C.beta_seq,sqrt(T.resMS{roi}));
+           
+            C.seq_ind=[1:6]';
+            C.sessN=ones(6,1)*sessN;
+            C.roi=ones(6,1)*roi;
+
+            P.beta_mean=mean(C.beta_seq,1);   % mean pattern acros digit in each session
+            P.zscore_mean=mean(C.zscore_seq,1);
+            %P.zscore_mean=bsxfun(@rdivide,P.beta_mean,sqrt(T.resMS{roi}));
+            P.sessN=sessN;
+            P.roi=roi;
+            
+            CS=addstruct(CS,C);
+            PS=addstruct(PS,P);
+        end
+        
+        ind = indicatorMatrix('allpairs',([1:4]));  % betwSess indicator
+        for n=1:numel(unique(CS.seq_ind))
+            T = getrow(CS,CS.seq_ind==n);
+            for i=1:size(ind,1)
+                [i1 i2] = find(ind(i,:)~=0);
+                if rm == 1
+                    AcrSess_b(i)=corr(T.beta_seq(i1(2),:)',T.beta_seq(i2(2),:)');
+                    AcrSess_z(i)=corr(T.zscore_seq(i1(2),:)',T.zscore_seq(i2(2),:)');
+                    AcrSess_p(i)=corr(T.psc_seq(i1(2),:)',T.psc_seq(i2(2),:)');
+                elseif rm == 0
+                    AcrSess_b(i)=corrN(T.beta_seq(i1(2),:)',T.beta_seq(i2(2),:)');
+                    AcrSess_z(i)=corrN(T.zscore_seq(i1(2),:)',T.zscore_seq(i2(2),:)');
+                    AcrSess_z(i)=corrN(T.psc_seq(i1(2),:)',T.psc_seq(i2(2),:)');
+                end
+            end
+            AcrSess_beta(n)=mean(AcrSess_b);
+            AcrSess_zscore(n)=mean(AcrSess_z);
+            AcrSess_psc(n)=mean(AcrSess_p);
+        end
+        Consist.beta_corr(roi,:) = AcrSess_beta;
+        Consist.zscore_corr(roi,:) = AcrSess_zscore;
+        Consist.psc_corr(roi,:) = AcrSess_psc;
+        Consist.beta_RSA(roi,1) = rsa_patternConsistency(CS.beta_seq,CS.sessN,CS.seq_ind,'removeMean',rm);
+        Consist.zscore_RSA(roi,1) = rsa_patternConsistency(CS.zscore_seq,CS.sessN,CS.seq_ind,'removeMean',rm);
+        Consist.roi(roi,1) = roi;
+        
+       end
+       
+        figure(1)
+        col=hsv(7);
+        for i = reg
+            a(i)=plot(Consist.beta_corr(i,:),'-o','Color',col(i,:));
+            hold on;
+            drawline(Consist.beta_RSA(i),'dir','horz','color',col(i,:));
+        end
+        title('Beta values')
+        legend(a,regname(reg));
+        xlabel('All across-session combinations');
+        ylabel('Correlation / RSA consistency(line)')
+        
+        figure(2)
+        for j=reg
+            b(j)=plot(Consist.zscore_corr(j,:),'-o','Color',col(j,:));
+            hold on;
+            drawline(Consist.zscore_RSA(j),'dir','horz','color',col(j,:));
+        end
+        title('Z scores')
+        legend(b,regname(reg));
+        xlabel('All across-session combinations');
+        ylabel('Correlation / RSA consistency(line)');
+        
+        keyboard;
+        
+    case 'ROI_beta_consist_betwSess_LOC'
+        % evaluate consistency of measures (psc, beta, z-scores) across
+        % sessions for finger mapping
+        
+        sn  = 1;
+        sessN = 1;
+        reg = 1:7;
+        keepmean=0;
+        betaChoice = 'multi'; % options: uni / multi / raw
+        vararginoptions(varargin,{'sn','sessN','reg','betaChoice','keepmean'});
+
+        
+       for  roi = reg;
+        CS=[];  % separate per digit
+        PS=[];  % across all digits
+        for sessN = 1:4; % per session
+            C=[];P=[];
             T = load(fullfile(regDir,sprintf('reg_LOC_betas_sess%d.mat',sessN))); % loads region data (T)
         
             switch (betaChoice)
@@ -2758,22 +2909,99 @@ switch(what)
             PS=addstruct(PS,P);
         end
         
-        O.overall = mean(PS.beta_mean,2);    % one value per session
-        O.overall = [O.overall;mean(PS.zscore_mean,2)];
-        O.indx = [ones(4,1);ones(4,1)*2];   % 1-beta, 2-zscore
+        O.betas(roi,:) = mean(PS.beta_mean,2)';    % one value per session
+        O.zscore(roi,:) = mean(PS.zscore_mean,2)';
+        O.roi(roi,1) = roi;
         
         ind = indicatorMatrix('allpairs',([1:4]));  % betwSess indicator
         for i=1:size(ind,1)
             [i1 i2] = find(ind(i,:)~=0);
-            Consist_beta(i,1)=corrN(PS.beta_mean(i1(2),:)',PS.beta_mean(i2(2),:)');
-            Consist_zscore(i,1)=corrN(PS.zscore_mean(i1(2),:)',PS.zscore_mean(i2(2),:)');
+            if keepmean == 0
+                Consist.beta(roi,i)=corr(PS.beta_mean(i1(2),:)',PS.beta_mean(i2(2),:)');
+                Consist.zscore(roi,i)=corr(PS.zscore_mean(i1(2),:)',PS.zscore_mean(i2(2),:)');
+            elseif keepmean == 1
+                Consist.beta(roi,i)=corrN(PS.beta_mean(i1(2),:)',PS.beta_mean(i2(2),:)');
+                Consist.zscore(roi,i)=corrN(PS.zscore_mean(i1(2),:)',PS.zscore_mean(i2(2),:)');
+            end
         end
         
-        Consist_beta_RSA = rsa_patternConsistency(CS.beta_digit,CS.sessN,CS.digit_ind,'removeMean','keepmean');
-        Consist_zscore_RSA = rsa_patternConsistency(CS.zscore_digit,CS.sessN,CS.digit_ind,'removeMean','keepmean');
+        Consist.beta_RSA(roi,1) = rsa_patternConsistency(CS.beta_digit,CS.sessN,CS.digit_ind,'removeMean',keepmean);
+        Consist.zscore_RSA(roi,1) = rsa_patternConsistency(CS.zscore_digit,CS.sessN,CS.digit_ind,'removeMean',keepmean);
+        Consist.roi(roi,1) = roi;
         
-        % add figures
+       end
+       
+        figure(1)
+        col=hsv(7);
+        for i = reg
+            a(i)=plot(Consist.beta(i,:),'-o','Color',col(i,:));
+            hold on;
+            drawline(Consist.beta_RSA(i),'dir','horz','color',col(i,:));
+        end
+        title('Beta values')
+        legend(a,regname(reg));
+        xlabel('All across-session combinations');
+        ylabel('Correlation / RSA consistency(line)')
         
+        figure(2)
+        for j=reg
+            b(j)=plot(Consist.zscore(j,:),'-o','Color',col(j,:));
+            hold on;
+            drawline(Consist.zscore_RSA(j),'dir','horz','color',col(j,:));
+        end
+        title('Z scores')
+        legend(b,regname(reg));
+        xlabel('All across-session combinations');
+        ylabel('Correlation / RSA consistency(line)')
+    case 'ROI_beta_consist_witSess_LOC'
+        % pattern consistency for specified roi
+        % Pattern consistency is a measure of the proportion of explained
+        % beta variance across runs within conditions. 
+        % 
+        % This stat is useful for determining which GLM model yields least
+        % variable beta estimates. That GLM should be the one you use for
+        % future analysis cases.
+        %
+        % enter sn, region, glm #, beta: 0=betaW, 1=betaUW, 2=raw betas
+        % (1) Set parameters
+        sessN = 1;
+        sn  = 1;
+        roi = 2; % default LH primary motor cortex
+        betaChoice = 'uw';  % raw / uw / mw 
+        keepmean = 0; % are we removing pattern means for patternconsistency?
+        vararginoptions(varargin,{'sn','glm','roi','betaChoice','keepmean','sessN'});
+
+        Rreturn=[];
+        %========%
+        for s=sessN
+            T = load(fullfile(regDir,sprintf('reg_LOC_betas_sess%d.mat',s))); % loads in struct 'T'
+            for r=roi
+                Rall=[]; %prep output variable
+                for s=sn
+                    S = getrow(T,(T.SN==s & T.region==r));
+                    runs = 1:numruns_loc_sess; % 2 func runs
+                    switch(betaChoice)
+                        case 'raw'
+                            betaW  = S.betaW{1}; 
+                        case 'uw'
+                            betaW  = S.betaUW{1}; 
+                        case 'mw'
+                            betaW  = S.betaRAW{1}; 
+                    end
+                    
+                    % make vectors for pattern consistency func
+                    conditionVec = kron(ones(numel(runs),1),[1:5]');
+                    partition    = kron(runs',ones(5,1));
+                    % calculate the pattern consistency
+                    R2   = rsa_patternConsistency(betaW,partition,conditionVec,'removeMean',keepmean);
+                    Rall = [Rall,R2];
+                end
+                Rreturn = [Rreturn;Rall];
+            end
+        end
+        varargout = {Rreturn};
+        fprintf('The consistency for %s betas in region %s is',betaChoice,regname{roi});
+        % output arranged such that each row is an roi, each col is subj
         
     case 'ROI_dimensionality'
         % estimating the dimensionality of patterns 
@@ -2794,10 +3022,10 @@ switch(what)
             title(sprintf('Session %d',s));
             hold on;
             plot(eigTrain_sum,'-o','Color','b');
-            legend('trained');
+            legend('trained','Location','northwest');
             subplot(2,4,4+s)
             plot(eigUntrain_sum,'-o','Color','r');
-            legend('untrained');
+            legend('untrained','Location','northwest');
         end
     case 'ROI_dim_LOC'
         % estimating the dimensionality of patterns 


### PR DESCRIPTION
Additional cases:
- MASK_combine (combines masks from all glms per subject - used in ROI)
- ROI_define - takes the mask from mask_combine
- Additional: ROI_define_sess - takes the mask per glm - used if inspecting regional activation before all scans completed
- smaller changes in ROI consistency cases - between / within sessions